### PR TITLE
Update stylesheet to fix misaligned button titles

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -153,9 +153,9 @@ a.button:hover {
 }
 
 a.button span {
-  padding-left: 50px;
   display: block;
   height: 23px;
+  text-align: center;
 }
 
 #download-zip span {
@@ -166,6 +166,7 @@ a.button span {
 }
 #view-on-github span {
   background: transparent url(../images/octocat-icon.png) 12px 50% no-repeat;
+  padding-left: 30px;
 }
 #view-on-github {
   margin-right: 0;


### PR DESCRIPTION
I updated the stylesheet to fix the weird spacing on the button labels for your github page. This changes from this:
![image](https://cloud.githubusercontent.com/assets/1237498/2558434/95cc266a-b748-11e3-9de7-4c164e44684b.png)

To this:
![image](https://cloud.githubusercontent.com/assets/1237498/2558435/a6854f0e-b748-11e3-9231-18730343ab24.png)
