### PR TITLE
Constraints Extensibility

### DIFF
--- a/lib/nyny/request_scope.rb
+++ b/lib/nyny/request_scope.rb
@@ -5,6 +5,8 @@ module NYNY
   class RequestScope
     extend Forwardable
 
+    Request = NYNY::Request
+
     attr_reader :request, :response
     def_delegators :request, :session, :params
     def_delegators :response, :headers

--- a/lib/nyny/router.rb
+++ b/lib/nyny/router.rb
@@ -30,7 +30,7 @@ module NYNY
       routes = ActionDispatch::Journey::Routes.new
       @journey = ActionDispatch::Journey::Router.new(routes, {
         :parameters_key => 'nyny.params',
-        :request_class => NYNY::Request
+        :request_class => scope_class::Request
       })
 
       route_defs.each do |path, options, handler|


### PR DESCRIPTION
Use RequestScope::Request to make constraints extensible with own methods on Request